### PR TITLE
Fix disabled login button

### DIFF
--- a/src/src/components/auth/signInWithTfa.vue
+++ b/src/src/components/auth/signInWithTfa.vue
@@ -42,13 +42,9 @@
                             </div>
 
                             <div class="v-card-actions">
-                                <v-btn
-                                    id="submit2-btn"
-                                    color="primary"
-                                    type="submit"
-                                    :disabled="signingIn || !isFormValid"
-                                    >{{ t("button.signIn") }}</v-btn
-                                >
+                                <v-btn id="submit2-btn" color="primary" type="submit" :disabled="signingIn">{{
+                                    t("button.signIn")
+                                }}</v-btn>
                             </div>
 
                             <p class="text-center mb-4">


### PR DESCRIPTION
Login button was permanently disabled because it was using a made up variable called `isFormValid` 