### PR TITLE
Expose overridable functions from useEntityGridCrud

### DIFF
--- a/src/src/js/entityCrud/useEntityCrud.ts
+++ b/src/src/js/entityCrud/useEntityCrud.ts
@@ -9,6 +9,7 @@ export type OverridableFunctions<T> = {
     onDeleteEntityButtonClickedOverride?: (id: T) => void;
     onEntityUpdatedOverride?: () => void;
     onEntityDeletedOverride?: () => void;
+    onEntityLoadedOverride?: () => void;
 };
 
 export default function useEntityCrud<TEntity extends Entity<T>, T>(
@@ -88,6 +89,9 @@ export default function useEntityCrud<TEntity extends Entity<T>, T>(
         // (1) a new entity is created(when we add a new entity)
         // (2) an entity is retrieved from server (when we edit an entity)
         //Please override it if you need to perform any additional operations on this event
+        if (overridableFunctions?.onEntityLoadedOverride) {
+            overridableFunctions.onEntityLoadedOverride();
+        }
     }
 
     function onEntityUpdated(): void {

--- a/src/src/js/entityCrud/useEntityGridCrud.ts
+++ b/src/src/js/entityCrud/useEntityGridCrud.ts
@@ -5,7 +5,7 @@ import type { Entity, EntityBuilder } from "@js/dataModels/entity";
 import type EntityApiClient from "@js/api/entityApiClient";
 import { onMounted, ref, type Ref } from "vue";
 import type ObVuetifyGrid from "@components/obComponents/grids/obVuetifyGrid.vue";
-import useEntityCrud from "./useEntityCrud";
+import useEntityCrud, { type OverridableFunctions } from "./useEntityCrud";
 
 export default function useEntityGridCrud<TEntity extends Entity<T>, T, TGrid extends EntityGrid>(
     provideEntityBuilder: EntityBuilder<TEntity, T>,
@@ -16,6 +16,7 @@ export default function useEntityGridCrud<TEntity extends Entity<T>, T, TGrid ex
         params: ConstructorParams<TEntity, T>,
         entityGrid: TGrid,
     ) => EntityUpdateStrategyWithGrid<TEntity, T, TGrid>,
+    overridableFunctions?: OverridableFunctions<T>,
 ) {
     const {
         entity,
@@ -60,6 +61,7 @@ export default function useEntityGridCrud<TEntity extends Entity<T>, T, TGrid ex
             onDeleteEntityButtonClickedOverride,
             onEntityUpdatedOverride,
             onEntityDeletedOverride,
+            onEntityLoadedOverride: overridableFunctions?.onEntityLoadedOverride,
         };
     }
 
@@ -84,6 +86,10 @@ export default function useEntityGridCrud<TEntity extends Entity<T>, T, TGrid ex
         tGrid.rememberCurrentPageBeforeGridAction(EntityGridAction.EntityDelete);
         showDeleteEntity.value = true;
         entity.value.id = id;
+
+        if (overridableFunctions?.onDeleteEntityButtonClickedOverride) {
+            overridableFunctions.onDeleteEntityButtonClickedOverride(id);
+        }
     }
 
     function onEntityUpdatedOverride(): void {
@@ -91,11 +97,19 @@ export default function useEntityGridCrud<TEntity extends Entity<T>, T, TGrid ex
         tGrid.restoreCurrentPage();
         showEntity.value = false;
         isEditingEntityInline.value = false;
+
+        if (overridableFunctions?.onEntityUpdatedOverride) {
+            overridableFunctions.onEntityUpdatedOverride();
+        }
     }
 
     function onEntityDeletedOverride(): void {
         //This event handler will be called after an entity is sucessfully deleted on server.
         tGrid.restoreCurrentPage();
+
+        if (overridableFunctions?.onEntityDeletedOverride) {
+            overridableFunctions.onEntityDeletedOverride();
+        }
     }
 
     return {


### PR DESCRIPTION
This should help @PunamDamania with an issue she was having. It also just makes sense to expose these functions for override. I'm a bit uncomfortable with how the overrides work - what if the dev wants to actually override the whole function, not just run their code afterwards? Or run their code before the code they're overriding? Maybe a job for a later redesign?