### PR TITLE
Added ability to add parentId into api calls

### DIFF
--- a/src/src/js/grids/vuetify/dataAdaptor.ts
+++ b/src/src/js/grids/vuetify/dataAdaptor.ts
@@ -4,9 +4,11 @@ import type { Query, OrderBy } from "@js/grids/vuetify/types";
 
 export class DataAdaptor extends ObApiClient {
     private readonly errorCallback: Function;
+    private readonly _parentId?: string;
 
-    constructor(apiBaseUrl: string, errorCallback: Function) {
+    constructor(apiBaseUrl: string, errorCallback: Function, parentId?: string) {
         super(apiBaseUrl);
+        this._parentId = parentId;
         this.errorCallback = errorCallback;
     }
 
@@ -20,6 +22,10 @@ export class DataAdaptor extends ObApiClient {
         filters.push(`page=${query.page}`);
         filters.push(`limit=${query.limit}`);
         filters.push(this.constructSortQuery(query.orderBy));
+
+        if (this._parentId) {
+            filters.push(`parentId=${this._parentId}`);
+        }
 
         const finalQuery = `?${filters.join("&")}`;
 

--- a/src/src/js/grids/vuetify/vuetifyEntityGrid.ts
+++ b/src/src/js/grids/vuetify/vuetifyEntityGrid.ts
@@ -87,8 +87,8 @@ export class VuetifyEntityGrid extends EntityGrid {
         }
     }
 
-    public initDataAdaptor(apiUrl: string, errorCallback: Function): void {
-        this._dataAdaptor = new DataAdaptor(apiUrl, errorCallback);
+    public initDataAdaptor(apiUrl: string, errorCallback: Function, parentId?: string): void {
+        this._dataAdaptor = new DataAdaptor(apiUrl, errorCallback, parentId);
     }
 
     public async refresh(): Promise<void> {


### PR DESCRIPTION
Should allow parentId by default on our grids so that if you're needing to grab data with a parentId filter..
We already provide a parentId in our API but never added it as a query parameter.

Should look something like this: 

```
  onBeforeMount(() => {
    entityGrid.initDataAdaptor(entityApiClient.apiUrl, onError, <parentId>);
  });
```

## Description
Added the ability to use parentId in UI

## Motivation and Context
Solves API being allowed to use parentId query parameter but Vuetify / Obelisk UI by default not having a parentId
