### PR TITLE
fix: api: change return type of getAll()

### DIFF
--- a/src/src/js/api/entityApiClient.ts
+++ b/src/src/js/api/entityApiClient.ts
@@ -14,9 +14,9 @@ export default class EntityApiClient<TEntity extends Entity<T>, T> extends ObRes
     }
 
     // Please use with care, this will retrieve all entities without any paging!
-    public async getAll(): Promise<PagedList<T>> {
+    public async getAll(): Promise<PagedList<TEntity>> {
         const data = await this.get();
-        return (await data.json()) as PagedList<T>;
+        return (await data.json()) as PagedList<TEntity>;
     }
 
     public async getEntity(id: T): Promise<TEntity> {


### PR DESCRIPTION
Adjusts the return type of `EntityApiClient.getAll()` to be more representative of what it actually returns

## Description
`EntityApiClient.getAll()` previously returned `Promise<PagedList<T>>`, where `T` is defined as the type of the entity's ID.
It actually returns, at runtime and after the promise is fulfilled etc, a PagedList of entities.

## Related Issue
#54 

## Motivation and Context
To fix a TypeScript type check error encountered if you create a typed ref and then try to assign its value to the awaited value of `entityApiClient.getAll()`

This is a pretty low priority bug to be honest as at runtime we don't get any issues, but it's just something I noticed
